### PR TITLE
fix: 修复前端国际化和时区显示问题

### DIFF
--- a/frontend/apps/veaiops/src/modules/event-center/features/history/ui/components/business/time-info.tsx
+++ b/frontend/apps/veaiops/src/modules/event-center/features/history/ui/components/business/time-info.tsx
@@ -15,7 +15,7 @@
 import { Typography } from '@arco-design/web-react';
 import { IconClockCircle, IconRefresh } from '@arco-design/web-react/icon';
 // ✅ 优化：使用最短路径，合并同源导入
-import { STYLES, type TimeInfoProps, formatTimeDisplay } from '@ec/shared';
+import { STYLES, type TimeInfoProps } from '@ec/shared';
 import { CellRender } from '@veaiops/components';
 import type React from 'react';
 
@@ -27,9 +27,6 @@ const { StampTime } = CellRender;
  * 显示事件的创建时间和更新时间
  */
 export const TimeInfo: React.FC<TimeInfoProps> = ({ selectedRecord }) => {
-  const createdTime = formatTimeDisplay(selectedRecord.created_at);
-  const updatedTime = formatTimeDisplay(selectedRecord.updated_at);
-
   return (
     <div className="grid grid-cols-2 gap-4">
       <div
@@ -46,8 +43,8 @@ export const TimeInfo: React.FC<TimeInfoProps> = ({ selectedRecord }) => {
             创建时间
           </Text>
         </div>
-        {createdTime ? (
-          <StampTime time={createdTime.getTime()} />
+        {selectedRecord.created_at ? (
+          <StampTime time={selectedRecord.created_at} />
         ) : (
           <Text style={{ color: STYLES.TEXT_SECONDARY }}>-</Text>
         )}
@@ -67,8 +64,8 @@ export const TimeInfo: React.FC<TimeInfoProps> = ({ selectedRecord }) => {
             更新时间
           </Text>
         </div>
-        {updatedTime ? (
-          <StampTime time={updatedTime.getTime()} />
+        {selectedRecord.updated_at ? (
+          <StampTime time={selectedRecord.updated_at} />
         ) : (
           <Text style={{ color: STYLES.TEXT_SECONDARY }}>-</Text>
         )}

--- a/frontend/apps/veaiops/src/modules/threshold/features/task-config/ui/version/filters.tsx
+++ b/frontend/apps/veaiops/src/modules/threshold/features/task-config/ui/version/filters.tsx
@@ -84,10 +84,10 @@ export const getTaskVersionFilters = ({
     },
     {
       field: 'create_time_range',
-      label: 'Created Time',
+      label: '创建时间',
       type: 'RangePicker',
       componentProps: {
-        placeholder: ['Start Time', 'End Time'],
+        placeholder: ['开始时间', '结束时间'],
         // Display: UTC → Local Time
         value:
           query?.createdAtStart && query?.createdAtEnd
@@ -128,10 +128,10 @@ export const getTaskVersionFilters = ({
     },
     {
       field: 'update_time_range',
-      label: 'Updated Time',
+      label: '更新时间',
       type: 'RangePicker',
       componentProps: {
-        placeholder: ['Start Time', 'End Time'],
+        placeholder: ['开始时间', '结束时间'],
         // Display: UTC → Local Time
         value:
           query?.updatedAtStart && query?.updatedAtEnd


### PR DESCRIPTION
- 智能阈值任务详情：将时间筛选框的英文标签翻译为中文
  - 'Created Time' → '创建时间'
  - 'Updated Time' → '更新时间'
  - 'Start Time' / 'End Time' → '开始时间' / '结束时间'

- 事件中心历史详情：修复时间显示时区错误
  - 移除不必要的时间转换逻辑
  - 直接传递UTC时间字符串给StampTime组件
  - 确保详情页面与列表页面时间显示一致