### PR TITLE
fix: Update API routing documentation for webhooks

### DIFF
--- a/docs/content/6.development/1.development.md
+++ b/docs/content/6.development/1.development.md
@@ -124,7 +124,7 @@ __all__ = ["LarkChannel", "WebhookChannel", "NewChannel", "REGISTRY"]
 
 #### API路由和事件处理
 
-> VeAIOps的核心API路由位于 `veaiops/handler/routers/apis/v1/chat.py`。它通过访问 `payload["header"]["event_type"]` 来接收和处理所有Channel的事件回调。您**无需修改**此文件，因为Channel注册机制会自动将请求分发到您实现的 `event_handle` 方法。
+> VeAIOps的核心API路由位于 `veaiops/handler/routers/apis/v1/webhooks.py`。它通过访问 `payload["header"]["event_type"]` 来接收和处理所有Channel的事件回调。您**无需修改**此文件，因为Channel注册机制会自动将请求分发到您实现的 `event_handle` 方法。
 
 您的主要工作是在 `event_handle` 方法中正确解析和处理来自新Channel平台的回调请求。
 


### PR DESCRIPTION
This pull request updates the documentation to correct the referenced file for the core API routing logic in VeAIOps. The documentation now points to the correct file responsible for handling channel event callbacks.

Documentation update:

* Updated the API routing documentation to reference `veaiops/handler/routers/apis/v1/webhooks.py` instead of the incorrect `chat.py` file, clarifying where the core event handling occurs.