### PR TITLE
fix(typing): Replace typing_extensions imports with standard typing i…

### DIFF
--- a/veaiops/metrics/base.py
+++ b/veaiops/metrics/base.py
@@ -17,10 +17,9 @@ import asyncio
 import functools
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
-from typing_extensions import Literal
 
 from veaiops.metrics.timeseries import InputTimeSeries
 from veaiops.schema.documents import (

--- a/veaiops/metrics/timeseries.py
+++ b/veaiops/metrics/timeseries.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 __all__ = ["InputTimeSeries"]
 

--- a/veaiops/utils/kb.py
+++ b/veaiops/utils/kb.py
@@ -14,10 +14,9 @@
 
 import json
 from datetime import datetime, timezone
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, override
 
 from tenacity import retry, stop_after_attempt, wait_fixed
-from typing_extensions import override
 from volcengine.ApiInfo import ApiInfo
 from volcengine.viking_knowledgebase import Collection, Doc, Point, VikingKnowledgeBaseService
 


### PR DESCRIPTION
This pull request updates type imports throughout the codebase to improve compatibility and adhere to modern Python standards. The main change is replacing imports from `typing_extensions` with imports from the standard library's `typing` module where appropriate.

**Type import modernization:**

* Replaced `Literal` import from `typing_extensions` with `Literal` from the standard library `typing` in `veaiops/metrics/base.py`.
* Replaced `TypedDict` import from `typing_extensions` with `TypedDict` from the standard library `typing` in `veaiops/metrics/timeseries.py`.
* Replaced `override` import from `typing_extensions` with `override` from the standard library `typing` in `veaiops/utils/kb.py`.…mports